### PR TITLE
Terraform変数をGitHub ActionsのSecretsから取得する構成に変更

### DIFF
--- a/.github/workflows/apply-base.yaml
+++ b/.github/workflows/apply-base.yaml
@@ -100,3 +100,6 @@ jobs:
           TFCMT_REPO_OWNER: ${{ github.event.organization.name }}
           TFCMT_REPO_NAME: ${{ github.event.repository.name }}
           TFCMT_PR_NUMBER: ${{ github.event.issue.number }}
+          # Terraform 変数として GitHub Secrets から値を設定
+          TF_VAR_allowed_ips: ${{ secrets.ALLOWED_IPS }}
+          TF_VAR_dd_api_key: ${{ secrets.DD_API_KEY }}

--- a/.github/workflows/plan-dispatch.yaml
+++ b/.github/workflows/plan-dispatch.yaml
@@ -85,3 +85,6 @@ jobs:
         working-directory: "./terraform"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Terraform 変数として GitHub Secrets から値を設定
+          TF_VAR_allowed_ips: ${{ secrets.ALLOWED_IPS }}
+          TF_VAR_dd_api_key: ${{ secrets.DD_API_KEY }}

--- a/.github/workflows/plan.yaml
+++ b/.github/workflows/plan.yaml
@@ -73,3 +73,6 @@ jobs:
         working-directory: "./terraform"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Terraform 変数として GitHub Secrets から値を設定
+          TF_VAR_allowed_ips: ${{ secrets.ALLOWED_IPS }}
+          TF_VAR_dd_api_key: ${{ secrets.DD_API_KEY }}


### PR DESCRIPTION
## WHY
Terraform変数をGitHub ActionsのSecretsから取得する構成に変更

## WHAT
<!-- このPRで何ができる or できないようになるのかの概要を記述 -->

## 確認方法
<!-- このPRの動作確認として何を確認すべきかを記述 -->

## :warning: 影響範囲
<!--- このPRが影響する範囲を箇条書きで列挙していく-->

## LINKS
<!--- JIRAなどの関連リンクを箇条書きで列挙していく -->

## 備考
<!-- いろいろ書いてよい。-->

## 反映作業
terraform apply を自動化するための PR コメントの形式を記載します

PR のコメント内にて、`/apply` の形式で PR コメントを書き込むと GitHub Actions のワークフローで terraform apply が実行されるようになっています。
PR が Approve されていないとワークフローがスキップされるので注意して下さい。

※ PR の概要に上記のコマンドを書き込んでも GitHub Actions のワークフローは実行されないので、PR の概要から上記のコマンドの記載を削除する必要はありません。

`/apply` が成功すると以下のようになります。
<details>
<summary>terraform apply の実行結果</summary>

![例：terraform apply の実行結果](terraform-apply-image.png)

</details>
